### PR TITLE
Remove Freenom

### DIFF
--- a/data/Domains.md
+++ b/data/Domains.md
@@ -5,7 +5,6 @@
 | [cluster.ws & wip.la](https://github.com/Olivr/free-domain) | Free cluster.ws and wip.la subdomains for developers. |
 | [eu.org](https://nic.eu.org) | Free eu.org domain. Request is usually approved in 14 days. |
 | [Free Domains](https://freesubdomains.org) | Free subdomains for personal sites, open-source projects, and more. |
-| [Freenom](https://freenom.com) | Free .tk, .ml, .ga, .cf, and .gq domains. |
 | [getlocalcert.net](https://www.getlocalcert.net) | Free subdomains for private network use. |
 | [is-a-good.dev](https://is-a-good.dev) | A free is-a-good-dev subdomain for developers. |
 | [is-a.dev](https://www.is-a.dev) | Free is-a.dev subdomain for developers. |


### PR DESCRIPTION
Freenom isn't a good option for free domain names any longer, can we remove it?

Domain registration has been halted due to a lawsuit, their website doesn't allow registration.
https://krebsonsecurity.com/2023/03/sued-by-meta-freenom-halts-domain-registrations/

Existing customer domains are getting taken down.
https://www.reddit.com/r/freenom/comments/154c1x8/ml_domains_are_getting_taken_down_and_no_longer/