### PR TITLE
DNS provider additions

### DIFF
--- a/data/DNS.md
+++ b/data/DNS.md
@@ -10,6 +10,7 @@
 | [Glauca](https://docs.glauca.digital/hexdns/) | Nameservers | Glauca offers free DNS hosting for up to 3 domains with DNSSEC support. |
 | [Google Public DNS](https://developers.google.com/speed/public-dns) | Resolver | Google Public DNS is a DNS service developed by Google. |
 | [Namecheap FreeDNS](https://www.namecheap.com/domains/freedns) | Nameservers | Namecheap FreeDNS allows you to keep your domain visible on the internet. It provides DNS hosting with secondary DNS backup to ensure availability. |
+| [NextDNS](https://nextdns.io) | Resolver | Similiar to AdGuard DNS, a DNS resolution service which allows you to specify allow/deny lists |
 | [No-IP](https://www.noip.com) | Nameservers | Create an easy to remember hostname and never lose your connection again. |
 | [OpenDNS](https://www.opendns.com) | Resolver | OpenDNS offers a suite of consumer products that aim to make your internet faster, safer, and more reliable. |
 | [Quad9](https://quad9.net) | Resolver | A security and privacy focused non-profit DNS service with no IP logging. |

--- a/data/DNS.md
+++ b/data/DNS.md
@@ -1,15 +1,15 @@
 ## DNS
 
-| Website | Description |
-|:-:|-|
-| [1.1.1.1](https://1.1.1.1) | S free public DNS resolver provided by Cloudflare with fast and secure DNS resolution. |
-| [AdGuard DNS](https://adguard-dns.io) | AdGuard DNS allows you to control web traffic on your devices by blocking ads, trackers, and malicious domains. |
-| [Bunny DNS](https://bunny.net/dns) | Bunny DNS provides DNS hosting with 20 million free queries. |
-| [Cloudflare](https://www.cloudflare.com/dns) | Cloudflare DNS is an enterprise-grade authoritative DNS service. It offers fast response times, high redundancy, advanced security features like built-in DDoS mitigation and DNSSEC. |
-| [Duck DNS](https://www.duckdns.org) | Duck DNS offers free dynamic DNS (DDNS) with support for up to 5 domains on the free tier. It provides configuration guides for various setups. |
-| [Glauca](https://docs.glauca.digital/hexdns) | Glauca offers free DNS hosting for up to 3 domains with DNSSEC support. |
-| [Google Public DNS](https://developers.google.com/speed/public-dns) | Google Public DNS is a DNS service developed by Google. |
-| [Namecheap FreeDNS](https://www.namecheap.com/domains/freedns) | Namecheap FreeDNS allows you to keep your domain visible on the internet. It provides DNS hosting with secondary DNS backup to ensure availability. |
-| [No-IP](https://www.noip.com) | Create an easy to remember hostname and never lose your connection again. |
-| [OpenDNS](https://www.opendns.com) | OpenDNS offers a suite of consumer products that aim to make your internet faster, safer, and more reliable. |
-| [Quad9](https://quad9.net) | A security and privacy focused non-profit DNS service with no IP logging. |
+| Website | Type | Description |
+|:-:|:-:|-|
+| [1.1.1.1](https://1.1.1.1) | Resolver | A free public DNS resolver provided by Cloudflare with fast and secure DNS resolution. |
+| [AdGuard DNS](https://adguard-dns.io) | Resolver | AdGuard DNS allows you to control web traffic on your devices by blocking ads, trackers, and malicious domains. |
+| [Bunny DNS](https://bunny.net/dns) | Nameservers | Bunny DNS provides DNS hosting with 20 million free queries. |
+| [Cloudflare](https://www.cloudflare.com/dns) | Nameservers | Cloudflare DNS is an enterprise-grade authoritative DNS service. It offers fast response times, high redundancy, advanced security features like built-in DDoS mitigation and DNSSEC. |
+| [Duck DNS](https://www.duckdns.org) | Nameservers | Duck DNS offers free dynamic DNS (DDNS) with support for up to 5 domains on the free tier. It provides configuration guides for various setups. |
+| [Glauca](https://docs.glauca.digital/hexdns/) | Nameservers | Glauca offers free DNS hosting for up to 3 domains with DNSSEC support. |
+| [Google Public DNS](https://developers.google.com/speed/public-dns) | Resolver | Google Public DNS is a DNS service developed by Google. |
+| [Namecheap FreeDNS](https://www.namecheap.com/domains/freedns) | Nameservers | Namecheap FreeDNS allows you to keep your domain visible on the internet. It provides DNS hosting with secondary DNS backup to ensure availability. |
+| [No-IP](https://www.noip.com) | Nameservers | Create an easy to remember hostname and never lose your connection again. |
+| [OpenDNS](https://www.opendns.com) | Resolver | OpenDNS offers a suite of consumer products that aim to make your internet faster, safer, and more reliable. |
+| [Quad9](https://quad9.net) | Resolver | A security and privacy focused non-profit DNS service with no IP logging. |

--- a/data/DNS.md
+++ b/data/DNS.md
@@ -12,3 +12,4 @@
 | [Namecheap FreeDNS](https://www.namecheap.com/domains/freedns) | Namecheap FreeDNS allows you to keep your domain visible on the internet. It provides DNS hosting with secondary DNS backup to ensure availability. |
 | [No-IP](https://www.noip.com) | Create an easy to remember hostname and never lose your connection again. |
 | [OpenDNS](https://www.opendns.com) | OpenDNS offers a suite of consumer products that aim to make your internet faster, safer, and more reliable. |
+| [Quad9](https://quad9.net) | A security and privacy focused non-profit DNS service with no IP logging. |


### PR DESCRIPTION
- Added additional providers (Quad9 + NextDNS)
- Fixed the URL for Glauca/HexDNS as it would lead to a 404 (fault of their documentation platform).
- Added additional column for discerning DNS provider type
  - `Resolvers` denote simply resolution services, a la 1.1.1.1, 9.9.9.9 or 8.8.8.8 (consumer focused).
  - `Nameservers` denote services used for their authoritative domain name resolution functions (developer focused).